### PR TITLE
[Issue-193] Don't show blocktime although perform transaction in wallet #193

### DIFF
--- a/packages/extension-base/src/services/chain-service/handler/bitcoin/strategy/BlockStream/index.ts
+++ b/packages/extension-base/src/services/chain-service/handler/bitcoin/strategy/BlockStream/index.ts
@@ -183,7 +183,7 @@ export class BlockStreamRequestStrategy extends BaseApiRequestStrategy implement
         const interval = setInterval(() => {
           this.getTransactionStatus(extrinsicHash)
             .then((transactionStatus) => {
-              if (transactionStatus.confirmed) {
+              if (transactionStatus.confirmed && transactionStatus.block_time > 0) {
                 clearInterval(interval);
                 eventEmitter.emit('success', transactionStatus);
               }


### PR DESCRIPTION
### Related issue(s)

- #193

### Is your feature request related to a problem(s)? Please describe.

- Add re-scan BTC transaction have no block_time
 
### Describe the solution you'd like

- Add re-scan BTC transaction have no block_time

### Describe alternatives you've considered

- No

### Additional context

- No
